### PR TITLE
automatically set app parameters

### DIFF
--- a/source/Plugins/GoogleAnalyticsV4/GoogleAnalyticsV4.cs
+++ b/source/Plugins/GoogleAnalyticsV4/GoogleAnalyticsV4.cs
@@ -150,6 +150,17 @@ public class GoogleAnalyticsV4 : MonoBehaviour {
       instance = this;
 
       DontDestroyOnLoad(instance);
+      
+      // automatically set app parameters from player settings if they are left empty
+      if(string.IsNullOrEmpty(productName)) {
+        productName = Application.productName;
+      }
+      if(string.IsNullOrEmpty(bundleIdentifier)) {
+        bundleIdentifier = Application.bundleIdentifier;
+      }
+      if(string.IsNullOrEmpty(bundleVersion)) {
+        bundleVersion = Application.version;
+      }
 
       Debug.Log("Initializing Google Analytics 0.2.");
 #if UNITY_ANDROID && !UNITY_EDITOR


### PR DESCRIPTION
- app parameters should be fetched from the unity player settings to keep them in sync when versions change
- this way they will only be set automatically when the fields are left empty, so it is still possible to overwrite the player settings